### PR TITLE
Add statement descriptor to receipt

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,7 +1,9 @@
 {
-  'extends': ['pagarme-base'],
-  'env': {
-    'node': true,
-  },
+  "extends": [
+    "pagarme-base"
+  ],
+  "env": {
+    "node": true,
+    "jest": true
+  }
 }
-

--- a/src/controllers/receipt.js
+++ b/src/controllers/receipt.js
@@ -6,6 +6,7 @@ const formatDate = require('../lib/date')
 const formatPaymentMethod = require('../lib/payment-method')
 const formatCaptureMethod = require('../lib/capture-method')
 const formatCardBrand = require('../lib/card-brand')
+const pickDescriptor = require('../lib/descriptor')
 
 const getLastReceipt = receiptId =>
   database.Receipt.findOne({
@@ -53,6 +54,7 @@ const render = (req, res) => {
       const receiptPaymentMethod = formatPaymentMethod(receipt.payment_method)
       const receiptCaptureMethod = formatCaptureMethod(receipt.capture_method)
       const receiptCardBrand = formatCardBrand(receipt.card_brand)
+      const receiptDescriptor = pickDescriptor(receipt)
 
       return res.render(
         'pages/receipt',
@@ -64,6 +66,7 @@ const render = (req, res) => {
           receiptPaymentMethod,
           receiptCaptureMethod,
           receiptCardBrand,
+          receiptDescriptor,
         }
       )
     })

--- a/src/database/migrations/20180724175208-add-statement-descriptor.js
+++ b/src/database/migrations/20180724175208-add-statement-descriptor.js
@@ -1,0 +1,13 @@
+const tableName = 'Receipts'
+const columnName = 'statement_descriptor'
+
+module.exports = {
+  up: (queryInterface, Sequelize) =>
+    queryInterface.addColumn(tableName, columnName, {
+      type: Sequelize.STRING,
+      allowNull: true,
+    }),
+
+  down: queryInterface =>
+    queryInterface.removeColumn(tableName, columnName),
+}

--- a/src/database/models/receipt.js
+++ b/src/database/models/receipt.js
@@ -87,6 +87,10 @@ module.exports = (sequelize, DataTypes) => {
       type: DataTypes.STRING,
       allowNull: true,
     },
+    statement_descriptor: {
+      type: DataTypes.STRING,
+      allowNull: true,
+    },
   }, {
     underscored: true,
     defaultScope: {

--- a/src/lib/descriptor.js
+++ b/src/lib/descriptor.js
@@ -1,0 +1,9 @@
+const pickDescriptor = ({
+  statement_descriptor: statementDescriptor,
+  soft_descriptor: softDescriptor,
+  seller_name: sellerName,
+}) =>
+  statementDescriptor ||
+  `pg *${(softDescriptor || sellerName || 'Pagar.me').substring(0, 18)}`
+
+module.exports = pickDescriptor

--- a/tests/e2e/helper.js
+++ b/tests/e2e/helper.js
@@ -18,7 +18,8 @@ const receiptData = {
   authorization_code: '4DDP1X',
   aid: '02199520',
   application_cryptogram: '5EC8B98ABC8F9E7597647CBCB9A75400',
-  soft_descriptor: 'pg* loja123',
+  soft_descriptor: 'loja123',
+  statement_descriptor: 'pg* loja123',
 }
 
 module.exports = {

--- a/tests/e2e/server.test.js
+++ b/tests/e2e/server.test.js
@@ -45,7 +45,8 @@ describe('API Tests', () => {
             authorization_code: '4DDP1X',
             aid: '02199520',
             application_cryptogram: '5EC8B98ABC8F9E7597647CBCB9A75400',
-            soft_descriptor: 'pg* loja123',
+            soft_descriptor: 'loja123',
+            statement_descriptor: 'pg* loja123',
           },
         })
       }))

--- a/tests/unit/descriptor.test.js
+++ b/tests/unit/descriptor.test.js
@@ -1,0 +1,20 @@
+const pickDescriptor = require('../../src/lib/descriptor')
+const {
+  mockReceiptDescriptorOne,
+  mockReceiptDescriptorTwo,
+  mockReceiptDescriptorThree,
+} = require('./helper')
+
+describe('Descriptor Lib', () => {
+  test('pickDescriptor should prioritize the statement_descriptor', () =>
+    expect(pickDescriptor(mockReceiptDescriptorOne)).toBe('pg *The Functional Dre'))
+
+  test('pickDescriptor should use the soft_descriptor if it has no statement_descriptor', () =>
+    expect(pickDescriptor(mockReceiptDescriptorTwo)).toBe('pg *The Functional Dre'))
+
+  test('pickDescriptor should use the seller_name if it has no soft_descriptor', () =>
+    expect(pickDescriptor(mockReceiptDescriptorThree)).toBe('pg *The Functional Dre'))
+
+  test('pickDescriptor should default to \'Não Informado\' if there is no seller_name', () =>
+    expect(pickDescriptor({})).toBe('pg *Pagar.me'))
+})

--- a/tests/unit/helper.js
+++ b/tests/unit/helper.js
@@ -18,7 +18,28 @@ const receiptData = {
   authorization_code: '4DDP1X',
   aid: '02199520',
   application_cryptogram: '5EC8B98ABC8F9E7597647CBCB9A75400',
-  soft_descriptor: 'pg* Loja 1 2 3',
+  soft_descriptor: 'Loja 1 2 3',
+  statement_descriptor: 'pg* Loja 1 2 3',
 }
 
-module.exports = { receiptData }
+const mockReceiptDescriptorOne = {
+  statement_descriptor: 'pg *The Functional Dre',
+  soft_descriptor: 'The Functional Dream',
+  seller_name: 'The Functional Dream',
+}
+
+const mockReceiptDescriptorTwo = {
+  soft_descriptor: 'The Functional Dream',
+  seller_name: 'The Functional Dream',
+}
+
+const mockReceiptDescriptorThree = {
+  seller_name: 'The Functional Dream',
+}
+
+module.exports = {
+  receiptData,
+  mockReceiptDescriptorOne,
+  mockReceiptDescriptorTwo,
+  mockReceiptDescriptorThree,
+}

--- a/tests/unit/receipt.test.js
+++ b/tests/unit/receipt.test.js
@@ -5,6 +5,7 @@ const formatDate = require('../../src/lib/date')
 const formatPaymentMethod = require('../../src/lib/payment-method')
 const formatCaptureMethod = require('../../src/lib/capture-method')
 const formatCardBrand = require('../../src/lib/card-brand')
+const pickDescriptor = require('../../src/lib/descriptor')
 const { receiptData } = require('./helper')
 
 const TEMPLATE_PATH = './views/pages/receipt.ejs'
@@ -23,6 +24,7 @@ describe('Rendered receipt template', () => {
         receiptCaptureMethod: formatCaptureMethod(receipt.capture_method),
         receiptCardBrand: formatCardBrand(receipt.card_brand),
         receiptDate: formatDate(receipt.payment_date),
+        receiptDescriptor: pickDescriptor(receipt),
         receipt,
       }
 
@@ -105,6 +107,7 @@ describe('Rendered receipt template', () => {
         receiptCaptureMethod: formatCaptureMethod(receipt.capture_method),
         receiptCardBrand: formatCardBrand(receipt.card_brand),
         receiptDate: formatDate(receipt.payment_date),
+        receiptDescriptor: pickDescriptor(receipt),
         receipt,
       }
 
@@ -132,7 +135,7 @@ describe('Rendered receipt template', () => {
       expect(renderedTemplate).toEqual(expect.stringContaining('no seu extrato como'))
     })
 
-    test('should have soft descriptor \'pg* Loja 1 2 3\'', () => {
+    test('should have statement descriptor \'pg* Loja 1 2 3\'', () => {
       expect(renderedTemplate).toEqual(expect.stringContaining('pg* Loja 1 2 3'))
     })
 
@@ -168,7 +171,7 @@ describe('Rendered receipt template', () => {
       expect(renderedTemplate).toEqual(expect.stringContaining('ONL-CHIP'))
     })
 
-    test('should have line \'Transação autorizada mediante uso de senha pessoal', () => {
+    test('should have line \'Transação autorizada mediante uso de senha pessoal\'', () => {
       expect(renderedTemplate).toEqual(expect.stringContaining('Transação autorizada mediante uso de senha pessoal'))
     })
   })
@@ -187,6 +190,7 @@ describe('Rendered receipt template', () => {
         receiptCaptureMethod: formatCaptureMethod(receipt.capture_method),
         receiptCardBrand: formatCardBrand(receipt.card_brand),
         receiptDate: formatDate(receipt.payment_date),
+        receiptDescriptor: pickDescriptor(receipt),
         receipt,
       }
 
@@ -214,7 +218,7 @@ describe('Rendered receipt template', () => {
       expect(renderedTemplate).toEqual(expect.stringContaining('na fatura do seu cartão como'))
     })
 
-    test('should have soft descriptor \'pg* Loja 1 2 3\'', () => {
+    test('should have statement descriptor \'pg* Loja 1 2 3\'', () => {
       expect(renderedTemplate).toEqual(expect.stringContaining('pg* Loja 1 2 3'))
     })
 

--- a/views/pages/receipt.ejs
+++ b/views/pages/receipt.ejs
@@ -345,7 +345,7 @@
                                                 na fatura do seu cartão como
                                               <% } %>
                                               <strong>
-                                                <%= receipt.soft_descriptor %>
+                                                <%= receiptDescriptor %>
                                               </strong>
                                             </p>
                                           </td>


### PR DESCRIPTION
## Description
Adds the statement descriptor to the receipt, with the following rules:
- In case a statement descriptor is passed, it will be used in the receipt;
- If not, if there is a soft descriptor, then it will be used but appended a `pg *`;
- And if there is no soft descriptor, the seller name will be used in the same constraints as above;
- In the last case scenario, we use `Pagar.me` if no information is provided.

## Changes Impact
`server`

## Dependencies and Blockers
None

## Your checklist for this pull request

:rotating_light: Please review this items for a good pull request. :four_leaf_clover:

1. I've read the project's [Contributing Guidelines](../CONTRIBUTING.md)
1. My commits are well written and follow [pagarme/git-style-guide](https://github.com/pagarme/git-style-guide)
1. My changes are well covered by **tests** and **logs**
1. I've updated the project docs (if needed)
1. I fell safe about this implementation
1. I feel comfortable with the code I wrote, and I'm not ashamed to show it to my friends

In a good pull request, everything above is true :relaxed:

