### PR TITLE
Improvement: add container healthcheck

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,6 +28,15 @@ ENV PORT 3000
 
 COPY --from=0 /tldr /tldr
 
+RUN apk --update add curl
+
 WORKDIR /tldr
+
+HEALTHCHECK \
+  --interval=5s \
+  --timeout=30s \
+  --start-period=10s \
+  --retries=3 \
+  CMD curl -f http://localhost:${PORT}/_health_check || exit 1
 
 EXPOSE ${PORT}

--- a/src/helpers/health-check.js
+++ b/src/helpers/health-check.js
@@ -1,0 +1,30 @@
+const { logger } = require('./escriba')
+
+const fetchItemFromSQS = async (Queue) => {
+  const {
+    sqs,
+    endpoint,
+  } = Queue.options
+
+  return sqs.receiveMessage({
+    QueueUrl: endpoint,
+    MaxNumberOfMessages: 1,
+    VisibilityTimeout: 0,
+  })
+    .promise()
+}
+
+const canFetchFromSQS = async (Queue) => {
+  try {
+    await fetchItemFromSQS(Queue)
+
+    return true
+  } catch (err) {
+    logger.error('Error on queue', err)
+    return false
+  }
+}
+
+module.exports = {
+  canFetchFromSQS,
+}

--- a/tests/e2e/worker.test.js
+++ b/tests/e2e/worker.test.js
@@ -39,5 +39,13 @@ describe('Worker Tests', () => {
     processReceipt({}, {})
       .then(result => expect(result).toBe(null)))
 
+  test('GET `/_health_check` should respond with status code `500`', () => {
+    ReceiptsQueue.options.endpoint = ''
+
+    return request(app)
+      .get('/_health_check')
+      .then(response => expect(response.statusCode).toBe(500))
+  })
+
   afterAll(database.sequelize.close)
 })

--- a/tests/integration/health-check.test.js
+++ b/tests/integration/health-check.test.js
@@ -1,0 +1,28 @@
+const { clone } = require('ramda')
+
+const { canFetchFromSQS } = require('../../src/helpers/health-check')
+const { ReceiptsQueue } = require('../../src/services/worker')
+
+
+describe('Healthcheck helper', () => {
+  describe('with invalid queue', () => {
+    let InvalidQueue
+
+    beforeAll(() => {
+      InvalidQueue = clone(ReceiptsQueue)
+      InvalidQueue.options.endpoint = ''
+    })
+
+    test('\'canFetchFromSQS\' should return \'false\'', async () => {
+      expect.assertions(1)
+      await expect(canFetchFromSQS(InvalidQueue)).resolves.toBe(false)
+    })
+  })
+
+  describe('with valid queue', () => {
+    test('\'canFetchFromSQS\' should return \'true\'', async () => {
+      expect.assertions(1)
+      await expect(canFetchFromSQS(ReceiptsQueue)).resolves.toBe(true)
+    })
+  })
+})


### PR DESCRIPTION
<!--
Use this template when submitting Pull Requests.
The HTML comments won't show when the issue is submitted. They're only for guidance.

All sections are mandatory.
-->

## Description
<!--
Describe the purpose of this Pull Request (PR).

This section should contain information on the problem this PR solves and the
methodology used to solve said problem.

If this PR is linked to any open issue, the reference should be here.

If this PR satisfies all conditions to close an issue, it should contain a line
that clearly states:

`Closes #<ISSUE_NUMBER>`
-->
As we're using ECS to deploy our server and worker, we need to ensure that the container is healthy.
With this PR, we use Docker's `HEALTHCHECK` instruction to ensure that everything is ok.
Instead of just returning `200` on the worker's route `/_health_check`, now tldr actually try to communicate with SQS (by getting an item) and if it works, return `200` as response to the HTTP request. Otherwhise, it logs the error and returns `500`.
## Changes Impact

<!--
Clearly descibre what the changes on this PR impact on the software / project.

What module(s) it could affect and what problems could arise from the changes.
-->
Affects the worker.
## Dependencies and Blockers

<!--
If this PR has any open dependency or a blocker, they should be listed on this
section.

Dependency is defined as another PR or known issue that needs to be solved before
this PR is merged.

Blocker is defined as anything that prevents this PR from being merged immediately.
-->

## Your checklist for this pull request

:rotating_light: Please review this items for a good pull request. :four_leaf_clover:

1. I've read the project's [Contributing Guidelines](../CONTRIBUTING.md)
1. My commits are well written and follow [pagarme/git-style-guide](https://github.com/pagarme/git-style-guide)
1. My changes are well covered by **tests** and **logs**
1. I've updated the project docs (if needed)
1. I fell safe about this implementation
1. I feel comfortable with the code I wrote, and I'm not ashamed to show it to my friends

In a good pull request, everything above is true :relaxed:

